### PR TITLE
[bionic] Add missing header

### DIFF
--- a/service/bad-url/exec-tool.cpp
+++ b/service/bad-url/exec-tool.cpp
@@ -19,6 +19,7 @@
 
 #include <ubuntu-app-launch/helper.h>
 #include <glib.h>
+#include <stdexcept>
 
 int
 main (int argc, char * argv[])


### PR DESCRIPTION
```
[...]/url-dispatcher/service/bad-url/exec-tool.cpp: In function ‘int main(int, char**)’:
[...]/url-dispatcher/service/bad-url/exec-tool.cpp:29:19: error: ‘runtime_error’ in namespace ‘std’ does not name a type
   29 |     } catch (std::runtime_error &e) {
      |                   ^~~~~~~~~~~~~
```